### PR TITLE
fix the actor related GNOME 46 bug/feature

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -64,7 +64,7 @@ const GraphOverlay = class StatsPlusGraphOverlay {
             reactive: true,
         });
 
-        this.actor.add_actor(this.label);
+        this.actor.add_child(this.label);
         Main.layoutManager.addChrome(this.actor);
         this.actor.hide();
     }
@@ -120,7 +120,7 @@ const HorizontalGraph = class StatsPlusHorizontalGraph {
             style_class: 'ssp-graph-area',
             reactive: true,
         });
-        this.actor.add_actor(this.graph);
+        this.actor.add_child(this.graph);
         this.actor.connect('style-changed', this._updateStyles.bind(this));
 
         this.graphoverlay = new GraphOverlay();
@@ -454,7 +454,7 @@ const Indicator = class StatsPlusIndicator {
             reactive: true,
             track_hover: true,
         });
-        this.actor.add_actor(this.drawing_area);
+        this.actor.add_child(this.drawing_area);
         this.actor.connect(
             'notify::visible',
             this._onVisibilityChanged.bind(this)
@@ -1460,7 +1460,7 @@ const SystemStatsPlus = class StatsPlusExtension {
             indicator.actor.connect('notify::hover', () => {
                 this._onHover(indicator);
             });
-            this._box.add_actor(indicator.actor);
+            this._box.add_child(indicator.actor);
             this._indicators.push(indicator);
         }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,10 +6,10 @@
   "name": "SystemStatsPlus",
   "original-author": "joe@thrallingpenguin.com",
   "shell-version": [
-    "45"
+    "46"
   ],
   "url": "https://github.com/remulocosta/system-stats-plus",
   "uuid": "system-stats-plus@remulo.costa.gmail.com",
-  "version-name": "0.1.0",
-  "version": 2
+  "version-name": "0.2.0",
+  "version": 3
 }


### PR DESCRIPTION
The extension can start after this but sadly it is not enough

![image](https://github.com/remulocosta/system-stats-plus/assets/3964568/d057014e-e0fe-48b0-bcfd-cb3479545b37)

On the panel the real-time bars are not working. But it does not cause any error in the journal.

```bash
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] indicator::enable SystemStatsPlusNetworkIndicator
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] indicator::enable StatsPlusSwapIndicator
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] indicator::enable StatsPlusMemoryIndicator
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] indicator::enable StatsPlusCpuIndicator
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] enable
ápr 02 10:26:59 AMANDA gnome-shell[3069]: [EXTENSION SystemStatsPlus] Interfaces found: 2
```

**I am not a GNOME developer, I just had 15 minutes in this morning. If anybody knows the solution for the bars, tell me. :) This is an awesome extension, should be part of the GNOME project as a default extension option.**